### PR TITLE
Removed TargetFrameworkVersion to test action

### DIFF
--- a/ValidationCore/LuhnCheck/LuhnCheck.csproj
+++ b/ValidationCore/LuhnCheck/LuhnCheck.csproj
@@ -8,7 +8,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>LuhnCheck</RootNamespace>
     <AssemblyName>LuhnCheck</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/ValidationCore/LuhnLibrary/LuhnLibrary.csproj
+++ b/ValidationCore/LuhnLibrary/LuhnLibrary.csproj
@@ -9,7 +9,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LuhnLibrary</RootNamespace>
     <AssemblyName>LuhnLibrary</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Since it seems to be `<TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>`  in the .csproj files that is causing the build to error, testing to see if the error resolves with the framework version removed from both .csproj files.