### PR TITLE
Remove superfluous branch reference from workflow

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,10 +1,6 @@
 name: .NET Core
 
-on:
-  push:
-    branches: [ ${GITHUB_REF##*/} ]
-  pull_request:
-    branches: [ ${GITHUB_REF##*/} ]
+on: [ push , pull_request ]
 
 jobs:
   build:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -2,9 +2,9 @@ name: .NET Core
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master , algorithm-correction ]
   pull_request:
-    branches: [ master ]
+    branches: [ master , algorithm-correction ]
 
 jobs:
   build:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -2,9 +2,9 @@ name: .NET Core
 
 on:
   push:
-    branches: [ master , algorithm-correction ]
+    branches: [ algorithm-correction ]
   pull_request:
-    branches: [ master , algorithm-correction ]
+    branches: [ algorithm-correction ]
 
 jobs:
   build:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -2,9 +2,9 @@ name: .NET Core
 
 on:
   push:
-    branches: [ algorithm-correction ]
+    branches: [ ${GITHUB_REF##*/} ]
   pull_request:
-    branches: [ algorithm-correction ]
+    branches: [ ${GITHUB_REF##*/} ]
 
 jobs:
   build:


### PR DESCRIPTION
The workflow was not triggering correctly for pushes outside the main branch, so removed the branch keywords from the workflow so that it should only run for branch receiving the push or the pull request.